### PR TITLE
Add zoom to crop picmini

### DIFF
--- a/DotrModdingTool2IMGUI/ImageEditing/ImageCreator.cs
+++ b/DotrModdingTool2IMGUI/ImageEditing/ImageCreator.cs
@@ -624,7 +624,8 @@ public static class ImageSaver
         const int imageWidth = 40;
         const int imageHeight = 32;
 
-        uint[] palette = ImageCreator.ReadPalette(originalData, paletteOffset, paletteSize);
+        uint[] palette = GameImageManager.CurrentTexture.Palette;
+
         SKBitmap src = LoadSourceBitmap(bitmap, pngPath, imageWidth, imageHeight);
         bool disposeSrc = !ReferenceEquals(src, bitmap);
 

--- a/DotrModdingTool2IMGUI/ImageEditing/PaintCanvas.cs
+++ b/DotrModdingTool2IMGUI/ImageEditing/PaintCanvas.cs
@@ -23,6 +23,7 @@ public class PaintCanvas
     Texture2D texture;
     bool isDirty;
     bool textureCreated;
+    TextureFilter textureFilter = TextureFilter.Point;
 
 
     SKPoint? lastPaintPos;
@@ -98,8 +99,17 @@ public class PaintCanvas
         var img = Raylib.GenImageColor(Bitmap.Width, Bitmap.Height, Color.White);
         texture = Raylib.LoadTextureFromImage(img);
         Raylib.UnloadImage(img);
-        Raylib.SetTextureFilter(texture, TextureFilter.Point);
+        Raylib.SetTextureFilter(texture, textureFilter);
         textureCreated = true;
+    }
+
+    public void SetTextureFilter(TextureFilter filter)
+    {
+        textureFilter = filter;
+        if (textureCreated)
+        {
+            Raylib.SetTextureFilter(texture, textureFilter);
+        }
     }
 
 
@@ -200,7 +210,8 @@ public class PaintCanvas
 
     SKPaint MakePaint()
     {
-        var paint = new SKPaint {
+        var paint = new SKPaint
+        {
             IsAntialias = false,
             StrokeWidth = BrushSize,
             StrokeCap = SKStrokeCap.Round,

--- a/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
+++ b/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Text;
 using ImGuiNET;
+using Raylib_cs;
 using SkiaSharp;
 namespace DotrModdingTool2IMGUI;
 
@@ -47,6 +48,27 @@ public class TextureEditorWindow : IImGuiWindow
     bool picMiniCropMode = false;
     SKPointI picMiniCropOrigin = new(0, 0);
     PaintCanvas? picMiniFullCanvas = null;
+    float picMiniZoom = 1f;
+    int picMiniSrcW = 40;
+    int picMiniSrcH = 32;
+    PicMiniZoomFilter picMiniZoomFilter = PicMiniZoomFilter.Nearest;
+
+    enum PicMiniZoomFilter
+    {
+        Nearest,
+        Bilinear,
+        Trilinear,
+        Aniso4x
+    }
+
+    static TextureFilter ToTextureFilter(PicMiniZoomFilter mode) => mode switch
+    {
+        PicMiniZoomFilter.Nearest => TextureFilter.Point,
+        PicMiniZoomFilter.Bilinear => TextureFilter.Bilinear,
+        PicMiniZoomFilter.Trilinear => TextureFilter.Trilinear,
+        PicMiniZoomFilter.Aniso4x => TextureFilter.Anisotropic4X,
+        _ => TextureFilter.Point
+    };
 
     static readonly HashSet<ImageMrgFile> AllImagesLoadedOnly = new() {
         ImageMrgFile.Model,
@@ -378,6 +400,7 @@ public class TextureEditorWindow : IImGuiWindow
         {
             if (ImGui.RadioButton("Edit PicMini", !picMiniCropMode))
             {
+                if (picMiniCropMode) ApplyCurrentCrop();
                 picMiniCropMode = false;
             }
 
@@ -392,6 +415,20 @@ public class TextureEditorWindow : IImGuiWindow
                 }
 
                 LoadPicMiniFullSizeBackground(pictureIndex, currentIndex);
+            }
+
+            if (picMiniCropMode)
+            {
+                ImGui.SameLine();
+                if (ImGui.Button("Reset Zoom")) picMiniZoom = 1f;
+                ImGui.SameLine();
+                ImGui.Text($"Zoom: {picMiniZoom:0.00}x");
+
+                int filterIndex = (int)picMiniZoomFilter;
+                if (ImGui.Combo("Sampling", ref filterIndex, "Nearest\0Bilinear\0Trilinear\0Aniso4x\0"))
+                {
+                    picMiniZoomFilter = (PicMiniZoomFilter)filterIndex;
+                }
             }
         }
         ImGui.SetNextItemWidth(-1);
@@ -664,54 +701,75 @@ public class TextureEditorWindow : IImGuiWindow
         var dl = ImGui.GetWindowDrawList();
         int fullW = picMiniFullCanvas!.Width;
         int fullH = picMiniFullCanvas!.Height;
+        picMiniFullCanvas.SetTextureFilter(ToTextureFilter(picMiniZoomFilter));
+
+        picMiniSrcW = Math.Clamp((int)MathF.Round(40f / picMiniZoom), 1, fullW);
+        picMiniSrcH = Math.Clamp((int)MathF.Round(32f / picMiniZoom), 1, fullH);
+        picMiniCropOrigin.X = Math.Clamp(picMiniCropOrigin.X, 0, fullW - picMiniSrcW);
+        picMiniCropOrigin.Y = Math.Clamp(picMiniCropOrigin.Y, 0, fullH - picMiniSrcH);
 
         float aspect = (float)fullW / fullH;
-        Vector2 displaySize = availableSize.X / aspect <= availableSize.Y
+        Vector2 fitSize = availableSize.X / aspect <= availableSize.Y
             ? new Vector2(availableSize.X, availableSize.X / aspect)
             : new Vector2(availableSize.Y * aspect, availableSize.Y);
 
+        Vector2 displaySize = fitSize * picMiniZoom;
+        Vector2 imagePos = canvasPos + (availableSize - displaySize) / 2f;
+        Vector2 viewMin = canvasPos;
+        Vector2 viewMax = canvasPos + availableSize;
+
+        ImGui.PushClipRect(viewMin, viewMax, true);
+        ImGui.SetCursorScreenPos(imagePos);
         ImGui.Image(picMiniFullCanvas.GetTexturePtr(), displaySize);
 
         float scaleX = displaySize.X / fullW;
         float scaleY = displaySize.Y / fullH;
 
-        if (ImGui.IsItemHovered() && ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        Vector2 mouse = ImGui.GetMousePos();
+        bool mouseInViewport =
+            mouse.X >= viewMin.X && mouse.X <= viewMax.X &&
+            mouse.Y >= viewMin.Y && mouse.Y <= viewMax.Y;
+
+        if (mouseInViewport)
         {
-            Vector2 mouse = ImGui.GetMousePos();
-            int imgX = (int)((mouse.X - canvasPos.X) / scaleX);
-            int imgY = (int)((mouse.Y - canvasPos.Y) / scaleY);
-
-            int newX = Math.Clamp(imgX - 20, 0, fullW - 40);
-            int newY = Math.Clamp(imgY - 16, 0, fullH - 32);
-
-            if (newX != picMiniCropOrigin.X || newY != picMiniCropOrigin.Y)
+            float wheel = ImGui.GetIO().MouseWheel;
+            if (wheel != 0f)
             {
-                picMiniCropOrigin.X = newX;
-                picMiniCropOrigin.Y = newY;
+                picMiniZoom = Math.Clamp(picMiniZoom * MathF.Pow(1.1f, wheel), 0.2f, 16f);
 
-                using var cropped = new SKBitmap(40, 32, SKColorType.Bgra8888, SKAlphaType.Unpremul);
-                using var cropCanvas = new SKCanvas(cropped);
-                var srcRect = new SKRectI(picMiniCropOrigin.X, picMiniCropOrigin.Y,
-                    picMiniCropOrigin.X + 40, picMiniCropOrigin.Y + 32);
-                cropCanvas.DrawBitmap(picMiniFullCanvas.Bitmap, srcRect, new SKRect(0, 0, 40, 32));
+                ApplyCurrentCrop();
+            }
 
+            if (ImGui.IsMouseDown(ImGuiMouseButton.Left))
+            {
+                int imgX = (int)((mouse.X - imagePos.X) / scaleX);
+                int imgY = (int)((mouse.Y - imagePos.Y) / scaleY);
 
-                cropCanvas.Flush();
-                paintCanvas.LoadBitmap(cropped);
-                ImageCreator.BuildPaletteFromBitmap(picMiniFullCanvas.Bitmap, currentImageByteArray[GetCurrentIndex()]);
-                palette = ImageCreator.ExtractPalette();
+                int newX = Math.Clamp(imgX - picMiniSrcW / 2, 0, fullW - picMiniSrcW);
+                int newY = Math.Clamp(imgY - picMiniSrcH / 2, 0, fullH - picMiniSrcH);
 
+                if (newX != picMiniCropOrigin.X || newY != picMiniCropOrigin.Y)
+                {
+                    picMiniCropOrigin.X = newX;
+                    picMiniCropOrigin.Y = newY;
+                    ApplyCurrentCrop();
+                }
             }
         }
 
 
-        Vector2 cropMin = canvasPos + new Vector2(picMiniCropOrigin.X * scaleX, picMiniCropOrigin.Y * scaleY);
-        Vector2 cropMax = cropMin + new Vector2(40 * scaleX, 32 * scaleY);
+        Vector2 cropMin = imagePos + new Vector2(picMiniCropOrigin.X * scaleX, picMiniCropOrigin.Y * scaleY);
+        Vector2 cropMax = cropMin + new Vector2(picMiniSrcW * scaleX, picMiniSrcH * scaleY);
         dl.AddRectFilled(cropMin, cropMax, 0x33FFFFFF);
         dl.AddRect(cropMin, cropMax, 0xFFFFFFFF, 0, ImDrawFlags.None, 2f);
         dl.AddRect(cropMin - new Vector2(1, 1), cropMax + new Vector2(1, 1), 0xFF000000, 0, ImDrawFlags.None, 1f);
-        ImGui.SetTooltip($"Crop origin: ({picMiniCropOrigin.X}, {picMiniCropOrigin.Y})");
 
+        ImGui.PopClipRect();
+
+        if (mouseInViewport)
+        {
+            ImGui.SetTooltip($"Crop origin: ({picMiniCropOrigin.X}, {picMiniCropOrigin.Y}) | Zoom: {picMiniZoom:0.00}x");
+        }
     }
 
     void LoadPicMiniFullSizeBackground(int pictureIndex, int byteArrayIndex)
@@ -745,6 +803,30 @@ public class TextureEditorWindow : IImGuiWindow
         }
 
         paintCanvas = new PaintCanvas(GameImageManager.CurrentTexture.Bitmap);
+        palette = ImageCreator.ExtractPalette();
+    }
+
+    void ApplyCurrentCrop()
+    {
+        if (picMiniFullCanvas == null) return;
+        int fullW = picMiniFullCanvas.Width;
+        int fullH = picMiniFullCanvas.Height;
+
+        picMiniSrcW = Math.Clamp((int)MathF.Round(40f / picMiniZoom), 1, fullW);
+        picMiniSrcH = Math.Clamp((int)MathF.Round(32f / picMiniZoom), 1, fullH);
+        picMiniCropOrigin.X = Math.Clamp(picMiniCropOrigin.X, 0, fullW - picMiniSrcW);
+        picMiniCropOrigin.Y = Math.Clamp(picMiniCropOrigin.Y, 0, fullH - picMiniSrcH);
+
+        using var cropped = new SKBitmap(40, 32, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        using var cropCanvas = new SKCanvas(cropped);
+        var srcRect = new SKRectI(
+            picMiniCropOrigin.X, picMiniCropOrigin.Y,
+            picMiniCropOrigin.X + picMiniSrcW, picMiniCropOrigin.Y + picMiniSrcH
+        );
+        cropCanvas.DrawBitmap(picMiniFullCanvas.Bitmap, srcRect, new SKRect(0, 0, 40, 32));
+        cropCanvas.Flush();
+        paintCanvas.LoadBitmap(cropped);
+        ImageCreator.BuildPaletteFromBitmap(picMiniFullCanvas.Bitmap, currentImageByteArray[GetCurrentIndex()]);
         palette = ImageCreator.ExtractPalette();
     }
 

--- a/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
+++ b/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
@@ -61,13 +61,18 @@ public class TextureEditorWindow : IImGuiWindow
         Aniso4x
     }
 
-    static TextureFilter ToTextureFilter(PicMiniZoomFilter mode) => mode switch
-    {
+    static TextureFilter ToTextureFilter(PicMiniZoomFilter mode) => mode switch {
         PicMiniZoomFilter.Nearest => TextureFilter.Point,
         PicMiniZoomFilter.Bilinear => TextureFilter.Bilinear,
         PicMiniZoomFilter.Trilinear => TextureFilter.Trilinear,
-        PicMiniZoomFilter.Aniso4x => TextureFilter.Anisotropic4X,
         _ => TextureFilter.Point
+    };
+
+    static SKSamplingOptions ToSKSamplingOptions(PicMiniZoomFilter mode) => mode switch {
+        PicMiniZoomFilter.Nearest => new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None),
+        PicMiniZoomFilter.Bilinear => new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None),
+        PicMiniZoomFilter.Trilinear => new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear),
+        _ => new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None)
     };
 
     static readonly HashSet<ImageMrgFile> AllImagesLoadedOnly = new() {
@@ -83,7 +88,6 @@ public class TextureEditorWindow : IImGuiWindow
     public TextureEditorWindow()
     {
         EditorWindow.OnIsoLoaded += OnIsoLoaded;
-
     }
 
     ref int GetCurrentIndex()
@@ -271,11 +275,8 @@ public class TextureEditorWindow : IImGuiWindow
                 await DataAccess.Instance.LoadAllImages();
                 EditorWindow._modalPopup.Show($"Images Loaded",
                     "Loader", null, ImGuiModalPopup.ShowType.OneButton);
-
             });
-
         }
-
 
         if (ImGui.Button("Save Pic Buffer"))
         {
@@ -298,14 +299,11 @@ public class TextureEditorWindow : IImGuiWindow
             cropImageOnLoad = !cropImageOnLoad;
         }
 
-
         if (ImGui.Button("Load"))
         {
-
             paintCanvas?.loadImage(currentImageByteArray, currentIndex, cropImageOnLoad);
             palette = ImageCreator.ExtractPalette();
         }
-
 
         if (ImGui.Button("Export"))
         {
@@ -315,7 +313,6 @@ public class TextureEditorWindow : IImGuiWindow
         {
             _ = paintCanvas?.SaveAll();
         }
-
 
         ImGui.EndGroup();
         ImGui.SameLine();
@@ -394,13 +391,16 @@ public class TextureEditorWindow : IImGuiWindow
         ImGui.EndChild();
         ImGui.SameLine();
 
-        ImGui.BeginChild("Canvas", ImGui.GetContentRegionAvail());
+        ImGui.BeginChild("Canvas", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
 
         if (isPicMini)
         {
             if (ImGui.RadioButton("Edit PicMini", !picMiniCropMode))
             {
-                if (picMiniCropMode) ApplyCurrentCrop();
+                if (picMiniCropMode)
+                {
+                    ApplyCurrentCrop();
+                }
                 picMiniCropMode = false;
             }
 
@@ -413,7 +413,6 @@ public class TextureEditorWindow : IImGuiWindow
                 {
                     pictureIndex += 171;
                 }
-
                 LoadPicMiniFullSizeBackground(pictureIndex, currentIndex);
             }
 
@@ -423,14 +422,10 @@ public class TextureEditorWindow : IImGuiWindow
                 if (ImGui.Button("Reset Zoom")) picMiniZoom = 1f;
                 ImGui.SameLine();
                 ImGui.Text($"Zoom: {picMiniZoom:0.00}x");
-
-                int filterIndex = (int)picMiniZoomFilter;
-                if (ImGui.Combo("Sampling", ref filterIndex, "Nearest\0Bilinear\0Trilinear\0Aniso4x\0"))
-                {
-                    picMiniZoomFilter = (PicMiniZoomFilter)filterIndex;
-                }
             }
+
         }
+
         ImGui.SetNextItemWidth(-1);
         if (ImGui.BeginCombo("##MrgFile", currentMrgFile.ToString()))
         {
@@ -508,7 +503,6 @@ public class TextureEditorWindow : IImGuiWindow
                     .ToArray();
             }
 
-
             foreach (var (name, originalIndex) in filteredList)
             {
                 bool selected = originalIndex == currentIndex;
@@ -532,14 +526,28 @@ public class TextureEditorWindow : IImGuiWindow
                     }
 
                     paintCanvas.LoadBitmap(GameImageManager.CurrentTexture.Bitmap);
+                    if (isPicMini && !picMiniCropMode)
+                    {
+                        paintCanvas.SetTextureFilter(ToTextureFilter(picMiniZoomFilter));
+                    }
+
                     paintCanvas.ClearStack();
                     palette = ImageCreator.ExtractPalette();
                 }
             }
             ImGui.EndCombo();
         }
-
-
+        if ( currentMrgFile == ImageMrgFile.PicMini && !picMiniCropMode )
+        {
+            int filterIndex = (int)picMiniZoomFilter;
+            ImGui.SetNextItemWidth(-1);
+            if (ImGui.Combo("##Sampling", ref filterIndex, "Nearest\0Bilinear\0Trilinear\0"))
+            {
+                picMiniZoomFilter = (PicMiniZoomFilter)filterIndex;
+                paintCanvas.SetTextureFilter(ToTextureFilter(picMiniZoomFilter));
+                ApplyCurrentCrop();
+            }
+        }
         Vector2 canvasPos = ImGui.GetCursorScreenPos();
         Vector2 availableSize = ImGui.GetContentRegionAvail();
 
@@ -701,62 +709,62 @@ public class TextureEditorWindow : IImGuiWindow
         var dl = ImGui.GetWindowDrawList();
         int fullW = picMiniFullCanvas!.Width;
         int fullH = picMiniFullCanvas!.Height;
-        picMiniFullCanvas.SetTextureFilter(ToTextureFilter(picMiniZoomFilter));
 
         picMiniSrcW = Math.Clamp((int)MathF.Round(40f / picMiniZoom), 1, fullW);
         picMiniSrcH = Math.Clamp((int)MathF.Round(32f / picMiniZoom), 1, fullH);
         picMiniCropOrigin.X = Math.Clamp(picMiniCropOrigin.X, 0, fullW - picMiniSrcW);
         picMiniCropOrigin.Y = Math.Clamp(picMiniCropOrigin.Y, 0, fullH - picMiniSrcH);
 
-        float aspect = (float)fullW / fullH;
-        Vector2 fitSize = availableSize.X / aspect <= availableSize.Y
-            ? new Vector2(availableSize.X, availableSize.X / aspect)
-            : new Vector2(availableSize.Y * aspect, availableSize.Y);
+        Vector2 imageSize, imagePos;
 
-        Vector2 displaySize = fitSize * picMiniZoom;
-        Vector2 imagePos = canvasPos + (availableSize - displaySize) / 2f;
+        float imgAspect = (float)fullW / fullH;
+        float canvasAspect = availableSize.X / availableSize.Y;
+
+        if (imgAspect > canvasAspect)
+        {
+            imageSize = new Vector2(availableSize.X, availableSize.X / imgAspect);
+        }
+        else
+        {
+            imageSize = new Vector2(availableSize.Y * imgAspect, availableSize.Y);
+        }
+        imagePos = new Vector2(canvasPos.X + (availableSize.X - imageSize.X) / 2f, canvasPos.Y);
+
+        float scaleX = imageSize.X / fullW;
+        float scaleY = imageSize.Y / fullH;
+
         Vector2 viewMin = canvasPos;
         Vector2 viewMax = canvasPos + availableSize;
 
         ImGui.PushClipRect(viewMin, viewMax, true);
-        ImGui.SetCursorScreenPos(imagePos);
-        ImGui.Image(picMiniFullCanvas.GetTexturePtr(), displaySize);
-
-        float scaleX = displaySize.X / fullW;
-        float scaleY = displaySize.Y / fullH;
+        dl.AddImage(picMiniFullCanvas.GetTexturePtr(), imagePos, imagePos + imageSize);
+        ImGui.SetCursorScreenPos(canvasPos);
 
         Vector2 mouse = ImGui.GetMousePos();
         bool mouseInViewport =
             mouse.X >= viewMin.X && mouse.X <= viewMax.X &&
             mouse.Y >= viewMin.Y && mouse.Y <= viewMax.Y;
 
-        if (mouseInViewport)
+        if (mouseInViewport && (!ImGui.IsAnyItemActive() || ImGui.IsMouseDragging(ImGuiMouseButton.Left)))
         {
             float wheel = ImGui.GetIO().MouseWheel;
             if (wheel != 0f)
             {
                 picMiniZoom = Math.Clamp(picMiniZoom * MathF.Pow(1.1f, wheel), 0.2f, 16f);
-
+                CenterCropOnMouse(mouse, imagePos, scaleX, scaleY, fullW, fullH);
                 ApplyCurrentCrop();
             }
 
             if (ImGui.IsMouseDown(ImGuiMouseButton.Left))
             {
-                int imgX = (int)((mouse.X - imagePos.X) / scaleX);
-                int imgY = (int)((mouse.Y - imagePos.Y) / scaleY);
+                CenterCropOnMouse(mouse, imagePos, scaleX, scaleY, fullW, fullH);
+            }
 
-                int newX = Math.Clamp(imgX - picMiniSrcW / 2, 0, fullW - picMiniSrcW);
-                int newY = Math.Clamp(imgY - picMiniSrcH / 2, 0, fullH - picMiniSrcH);
-
-                if (newX != picMiniCropOrigin.X || newY != picMiniCropOrigin.Y)
-                {
-                    picMiniCropOrigin.X = newX;
-                    picMiniCropOrigin.Y = newY;
-                    ApplyCurrentCrop();
-                }
+            if (ImGui.IsMouseReleased(ImGuiMouseButton.Left))
+            {
+                ApplyCurrentCrop();
             }
         }
-
 
         Vector2 cropMin = imagePos + new Vector2(picMiniCropOrigin.X * scaleX, picMiniCropOrigin.Y * scaleY);
         Vector2 cropMax = cropMin + new Vector2(picMiniSrcW * scaleX, picMiniSrcH * scaleY);
@@ -772,6 +780,15 @@ public class TextureEditorWindow : IImGuiWindow
         }
     }
 
+    void CenterCropOnMouse(Vector2 mouse, Vector2 imagePos, float scaleX, float scaleY, int fullW, int fullH)
+    {
+        int imgX = (int)((mouse.X - imagePos.X) / scaleX);
+        int imgY = (int)((mouse.Y - imagePos.Y) / scaleY);
+
+        picMiniCropOrigin.X = Math.Clamp(imgX - picMiniSrcW / 2, 0, fullW - picMiniSrcW);
+        picMiniCropOrigin.Y = Math.Clamp(imgY - picMiniSrcH / 2, 0, fullH - picMiniSrcH);
+    }
+
     void LoadPicMiniFullSizeBackground(int pictureIndex, int byteArrayIndex)
     {
         var pictureBytes = GameImageManager.PictureBytes[pictureIndex];
@@ -779,7 +796,6 @@ public class TextureEditorWindow : IImGuiWindow
 
         picMiniFullCanvas?.Free();
         picMiniFullCanvas = new PaintCanvas(GameImageManager.CurrentTexture.Bitmap);
-
 
         ImageCreator.CreateImageFromBytes(currentImageByteArray[byteArrayIndex], currentMrgFile, "", false);
         picMiniCropOrigin.X = Math.Clamp(picMiniCropOrigin.X, 0, picMiniFullCanvas.Width - 40);
@@ -793,8 +809,7 @@ public class TextureEditorWindow : IImGuiWindow
 
         if (currentMrgFile == ImageMrgFile.Icon)
         {
-            GameImageManager.CurrentTexture.Bitmap = PS2Icon.ExtractIconTexture(
-                GameImageManager.IconImageBytes[PS2Icon.CurrentTextureIndex]);
+            GameImageManager.CurrentTexture.Bitmap = PS2Icon.ExtractIconTexture(GameImageManager.IconImageBytes[PS2Icon.CurrentTextureIndex]);
             PS2Icon.BuildPaletteFromBitmap(GameImageManager.CurrentTexture.Bitmap);
         }
         else
@@ -817,16 +832,23 @@ public class TextureEditorWindow : IImGuiWindow
         picMiniCropOrigin.X = Math.Clamp(picMiniCropOrigin.X, 0, fullW - picMiniSrcW);
         picMiniCropOrigin.Y = Math.Clamp(picMiniCropOrigin.Y, 0, fullH - picMiniSrcH);
 
-        using var cropped = new SKBitmap(40, 32, SKColorType.Bgra8888, SKAlphaType.Unpremul);
-        using var cropCanvas = new SKCanvas(cropped);
+        using SKBitmap cropped = new SKBitmap(40, 32, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        using SKCanvas cropCanvas = new SKCanvas(cropped);
         var srcRect = new SKRectI(
             picMiniCropOrigin.X, picMiniCropOrigin.Y,
             picMiniCropOrigin.X + picMiniSrcW, picMiniCropOrigin.Y + picMiniSrcH
         );
-        cropCanvas.DrawBitmap(picMiniFullCanvas.Bitmap, srcRect, new SKRect(0, 0, 40, 32));
+
+        using SKImage image = SKImage.FromBitmap(picMiniFullCanvas.Bitmap);
+        SKSamplingOptions sampling = ToSKSamplingOptions(picMiniZoomFilter);
+        cropCanvas.DrawImage(image, srcRect, new SKRect(0, 0, 40, 32), sampling);
         cropCanvas.Flush();
-        paintCanvas.LoadBitmap(cropped);
-        ImageCreator.BuildPaletteFromBitmap(picMiniFullCanvas.Bitmap, currentImageByteArray[GetCurrentIndex()]);
+
+
+        using SKBitmap converted = cropped.Copy(SKColorType.Rgba8888);
+        ImageCreator.BuildPaletteFromBitmap(converted, currentImageByteArray[GetCurrentIndex()]);
+
+        paintCanvas.LoadBitmap(converted);
         palette = ImageCreator.ExtractPalette();
     }
 

--- a/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
+++ b/DotrModdingTool2IMGUI/Windows/TextureEditorWindow.cs
@@ -51,6 +51,7 @@ public class TextureEditorWindow : IImGuiWindow
     float picMiniZoom = 1f;
     int picMiniSrcW = 40;
     int picMiniSrcH = 32;
+    bool centerMouseOnZoom = false;
     PicMiniZoomFilter picMiniZoomFilter = PicMiniZoomFilter.Nearest;
 
     enum PicMiniZoomFilter
@@ -422,6 +423,8 @@ public class TextureEditorWindow : IImGuiWindow
                 if (ImGui.Button("Reset Zoom")) picMiniZoom = 1f;
                 ImGui.SameLine();
                 ImGui.Text($"Zoom: {picMiniZoom:0.00}x");
+                ImGui.SameLine();
+                ImGui.Checkbox("Center on zoom", ref centerMouseOnZoom);
             }
 
         }
@@ -537,7 +540,7 @@ public class TextureEditorWindow : IImGuiWindow
             }
             ImGui.EndCombo();
         }
-        if ( currentMrgFile == ImageMrgFile.PicMini && !picMiniCropMode )
+        if (currentMrgFile == ImageMrgFile.PicMini && !picMiniCropMode)
         {
             int filterIndex = (int)picMiniZoomFilter;
             ImGui.SetNextItemWidth(-1);
@@ -751,7 +754,12 @@ public class TextureEditorWindow : IImGuiWindow
             if (wheel != 0f)
             {
                 picMiniZoom = Math.Clamp(picMiniZoom * MathF.Pow(1.1f, wheel), 0.2f, 16f);
-                CenterCropOnMouse(mouse, imagePos, scaleX, scaleY, fullW, fullH);
+                
+                if (centerMouseOnZoom)
+                {
+                    CenterCropOnMouse(mouse, imagePos, scaleX, scaleY, fullW, fullH);
+                }
+
                 ApplyCurrentCrop();
             }
 


### PR DESCRIPTION
Adds functionality to the "Crop from Picture" mode in order to create nice PicMinis by scrolling the scroll wheel.

Refactors the logic which applies the current crop into a new method which is called when either the zoom or the crop origin is changed.

Has support for 4 different filtering types